### PR TITLE
set name input to be readonly when bundle is selected

### DIFF
--- a/public/js/train.js
+++ b/public/js/train.js
@@ -225,6 +225,7 @@
 
   $positiveClearButton.click(function(e) {
     e.preventDefault();
+    $trainUrlInput.prop('readonly',false);
     resetPreviewsPositive();
     hidePreviewsPositive();
     setTrainButtonState();
@@ -235,6 +236,7 @@
 
   $negativeClearButton.click(function(e) {
     e.preventDefault();
+    $trainUrlInput.prop('readonly',false);
     resetPreviewsNegative();
     hidePreviewsNegative();
     setTrainButtonState();

--- a/public/js/train.js
+++ b/public/js/train.js
@@ -216,6 +216,7 @@
     resetPreviews();
     loadPreviews(positive, negative);
     $trainUrlInput.val(dataset.name);
+    $trainUrlInput.prop('readonly',true);
     showPreviews();
     setTrainButtonState();
     setInputErrorState();


### PR DESCRIPTION
When a user selects an image bundle for the trainer, the
name input is set to the name of the bundle. This input is supposed
to be read only at this point.

Fixes #64 