### PR TITLE
bugfix: when I click refresh, it deletes the example classifier name

### DIFF
--- a/public/js/train.js
+++ b/public/js/train.js
@@ -95,8 +95,10 @@ $(document).ready(function() {
       $('.showing div._examples--class__selected button').click();
     } else {
       $('form.upload')[0].reset();
-      $('input.base--input._examples--input-name').val('');
-      $('input.base--input._examples--input-name').prop('readonly', false);
+      if (!$('input.base--input._examples--input-name').prop('readonly')) {
+        $('input.base--input._examples--input-name').val('');
+        $('input.base--input._examples--input-name').prop('readonly', false);
+      }
     }
     enableTrainClassifier();
   });


### PR DESCRIPTION
This is fixed.  when using a bundle, reset doesn't reset the name.

Fixes https://github.ibm.com/Watson/developer-experience/issues/145
