### PR TITLE
Hides tests results when a new classifier is trained

### DIFF
--- a/public/js/train.js
+++ b/public/js/train.js
@@ -230,6 +230,7 @@ $(document).ready(function() {
   function resetPage() {
     $loading.hide();
     $error.hide();
+    $('.test--output.test--output-row').hide();
   }
 
   function showTrainingError(err) {


### PR DESCRIPTION
from https://github.ibm.com/Watson/developer-experience/issues/179  when
a new classifier is trained the old test results were not hidden.  Now
they are hidden.