### PR TITLE
Wording change in classifier name

### DIFF
--- a/public/js/train.js
+++ b/public/js/train.js
@@ -262,7 +262,7 @@ $(document).ready(function() {
     classifierNameMapping.insurance = {};
     classifierNameMapping.insurance.brokenwinshield = 'Broken Windshield';
     classifierNameMapping.insurance.flattire = 'Flat Tire';
-    classifierNameMapping.insurance.motorcycleaccident = 'Motorcycle Accident';
+    classifierNameMapping.insurance.motorcycleaccident = 'Motorcycle Involved';
     classifierNameMapping.insurance.vandalism = 'Vandalism';
     classifierNameMapping.moleskine = {};
     classifierNameMapping.moleskine.journaling = 'Journaling';


### PR DESCRIPTION
update "Motorcycle Accident" to be "Motorcycle Involved" so that it's
less specific and more in line with the quality of the training.
addresses https://github.ibm.com/Watson/developer-experience/issues/190