### PR TITLE
Use random is removed for user trained

### DIFF
--- a/public/js/train.js
+++ b/public/js/train.js
@@ -341,6 +341,13 @@ $(document).ready(function() {
             flashTrainedClassifer();
             scrollToElement($('.train--trained-successfully'), 65);
             $('.test--section').show();
+            if (params.bundle.kind === 'user') {
+              $('a.base--a.test--random-test-image').hide();
+              $('input[type=text].test--url-input.base--input').attr('placeholder', 'Paste an image URL');
+            } else {
+              $('a.base--a.test--random-test-image').show();
+              $('input[type=text].test--url-input.base--input').attr('placeholder', 'Or paste an image URL');
+            }
             $('.test--classifier').text($('input.base--input._examples--input-name').val());
             showTestPanel(classifier);
           });


### PR DESCRIPTION
When I train a classifier the wording in the
test form needs to be updated. Removes 'use random'
and changes placeholder for URL post to remove 'Or'