### PR TITLE
fixes width on classifier name

### DIFF
--- a/public/css/training.css
+++ b/public/css/training.css
@@ -230,6 +230,7 @@ img {
     color: #121212;
 }
 
+
 @media (max-width: 600px) {
 
     .train--row.showing {
@@ -660,5 +661,10 @@ input.base--input._examples--input-name {
 
 .bundle {
   padding-left: 0px;
+  width: 100%;
   border: none;
+}
+
+.bundle:focus {
+    outline: none;
 }


### PR DESCRIPTION
since the width of the classifier got lengthened with the
bundle pre-lable,  the width of the classifier name
sometimes got cropped.  This addresses https://github.ibm.com/Watson/developer-experience/issues/212