### PR TITLE
Fix issue with retraining form error messages

### DIFF
--- a/public/js/train.js
+++ b/public/js/train.js
@@ -216,6 +216,8 @@ $(document).ready(function() {
     return fileSizeOK(fileobj) && isValidMimeTypeForZip(fileobj.type)
   }
 
+  module.exports.isValidFile = isValidFile;
+
   let alertsForFileInvalidity = function(fileobj) {
     if (!fileSizeOK(fileobj)) {
       // eslint-disable-next-line no-alert
@@ -225,6 +227,8 @@ $(document).ready(function() {
       alert('You can only upload Zipped archives of images');
     }
   }
+
+  module.exports.alertsForFileInvalidity = alertsForFileInvalidity;
 
   $('.classifier input[type=file]').on('change', function(e) {
     var nameInput = $(e.target).parent().find('input[type=text]');


### PR DESCRIPTION
the retraining form didn't use the same error messages
as the other forms. This has been fixed.  Includes size and
mime type.  Fixes https://github.ibm.com/Watson/developer-experience/issues/645
except for design issues.