### PR TITLE
Enabling Content Security Policy

### DIFF
--- a/config/security.js
+++ b/config/security.js
@@ -24,16 +24,57 @@ var helmet = require('helmet');
 module.exports = function(app) {
   app.enable('trust proxy');
 
-  // 1. helmet with defaults
+  // 1. helmet with some customizations
+  var cspReportUrl = '/report-csp-violation';
+  var siteAllowedToIframeThis = 'https://watson-experience.mybluemix.net/';
   app.use(helmet({
-    cacheControl: false
-  }));
+    cacheControl: false,
+    frameguard: {
+      action: 'allow-from',
+      domain: siteAllowedToIframeThis
+    },
+    contentSecurityPolicy: {
+      // Specify directives as normal.
+      directives: {
+        defaultSrc: ["'self'"], // default value for unspecified directives that end in -src
+        scriptSrc: ["'self'", 'https://cdnjs.cloudflare.com/'], // jquery cdn, etc. try to avid "'unsafe-inline'"
+        //styleSrc: ["'self'"], // no inline css
+        imgSrc: ['*', 'data:'], // should be "'self'" and possibly 'data:' for most apps, but vr demo loads random user-supplied image urls, and apparently * doesn't include data: URIs
+        connectSrc: ["'self'", '*.watsonplatform.net', ' https://collector.tealeaf.ibmcloud.com/'], // ajax domains
+        //fontSrc: ["'self'"], // cdn?
+        objectSrc: [], // embeds (e.g. flash)
+        //mediaSrc: ["'self'", '*.watsonplatform.net'], // allow watson TTS streams
+        childSrc: [], // child iframes
+        frameAncestors: [siteAllowedToIframeThis], // parent iframes
+        formAction: ["'self'"], // where can forms submit to
+        pluginTypes: [], // e.g. flash, pdf
+        //sandbox: ['allow-forms', 'allow-scripts', 'allow-same-origin'], // options: allow-forms allow-same-origin allow-scripts allow-top-navigation
+        reportUri: cspReportUrl,
+      },
 
-  // Allow from a specific host:
-  app.use(helmet.frameguard({
-    action: 'allow-from',
-    domain: 'https://watson-experience.mybluemix.net/'
+      // Set to true if you only want browsers to report errors, not block them.
+      // You may also set this to a function(req, res) in order to decide dynamically
+      // whether to use reportOnly mode, e.g., to allow for a dynamic kill switch.
+      reportOnly: false,
+
+      // Set to true if you want to blindly set all headers: Content-Security-Policy,
+      // X-WebKit-CSP, and X-Content-Security-Policy.
+      setAllHeaders: false,
+
+      // Set to true if you want to disable CSP on Android where it can be buggy.
+      disableAndroid: false,
+
+      // Set to false if you want to completely disable any user-agent sniffing.
+      // This may make the headers less compatible but it will be much faster.
+      // This defaults to `true`.
+      browserSniff: true
+    }
   }));
+  // endpoint to report CSP violations
+  app.post(cspReportUrl, function(req, res) {
+    console.log('Content Security Policy Violation:\n', req.body);
+    res.status(204).send(); // 204 = No Content
+  });
 
   // 2. rate-limit to /api/
   app.use('/api/', rateLimit({
@@ -54,4 +95,5 @@ module.exports = function(app) {
     };
     next();
   });
+
 };

--- a/public/css/extra.css
+++ b/public/css/extra.css
@@ -23,6 +23,10 @@
   height: 2px;
 }
 
+.display-none {
+  display:none;
+}
+
 .container {
     width: auto;
     border-top: 1px solid #D6D7D6;

--- a/public/js/classresults.jsx
+++ b/public/js/classresults.jsx
@@ -253,7 +253,7 @@ class ClassifyScoreRow extends React.Component {
           <div className={this.scoreColor()}>
             {this.props.score}
           </div>
-          <img className="result--thermometer" src={"https://visual-recognition-demo.mybluemix.net/thermometer?score=" + this.props.score}/>
+          <img className="result--thermometer" src={"/thermometer?score=" + this.props.score}/>
         </div>
       </td>
     </tr>);
@@ -275,7 +275,7 @@ class AgeScoreRow extends ClassifyScoreRow {
           <div className={this.scoreColor()}>
             {this.props.score}
           </div>
-          <img className="result--thermometer" src={"https://visual-recognition-demo.mybluemix.net/thermometer?score=" + this.props.score}/>
+          <img className="result--thermometer" src={"/thermometer?score=" + this.props.score}/>
         </div>
       </td>
     </tr>);

--- a/public/js/use.js
+++ b/public/js/use.js
@@ -236,7 +236,8 @@ function setupUse(params) {
   /*
    * Random image submission
    */
-  $randomImage.click(function () {
+  $randomImage.click(function (e) {
+    e.preventDefault();
     resetPasteUrl();
     var kind = StateManager.getState().kind;
     var path = kind === 'user' ? '/samples/' : '/bundles/' + kind + '/test/';

--- a/views/includes/test.jade
+++ b/views/includes/test.jade
@@ -10,12 +10,12 @@
       button(title='Deletes the created classifier', type='reset').test--reset-button.base--a.icon-hyperlink--button.icon-hyperlink--button_BLANK.reset--classifier
         | Reset
     p.base--p.test--description Test your newly trained demo classifier with a similar image that was not in the training set.
-    a.base--a.test--random-test-image(href="javascript:void(0)") Use a system test image
+    a.base--a.test--random-test-image(href="#") Use a system test image
     form(id='test--fileupload', class='test--form test--dropzone', data-upload-template-id='template-upload-test')
       input(id='test_classifier_id', type='hidden', name='classifier_id')
       div(class='test--url')
-        div(class='test--invalid-url', style='display:none') Invalid URL
-        div(class='test--invalid-image-url', style='display:none') The URL must end with .JPG, .GIF, or .PNG.
+        div.test--invalid-url.display-none Invalid URL
+        div.test--invalid-image-url.display-none The URL must end with .JPG, .GIF, or .PNG.
         input(class='test--url-input base--input', type='text', placeholder='Or paste an image URL', name='url')
         input(class='test--image-data-input base--input', type='hidden', name='image_data')
       div(class='test--dropzone')
@@ -26,15 +26,15 @@
           span.test--file-input-button-drag-text  or drag
           |  your own image
         input(id='test--file', class='test--file-input', type='file', name='images_file', accept='image/x-png, image/jpg, image/gif, image/jpeg, image/png', title='Choose an image to upload')
-    .loading.test--loading(style='display:none')
+    .loading.test--loading.display-none
       .loader-container
         svg.loader(viewBox='25 25 50 50')
           circle.loader__path(cx='50', cy='50', r='20')
       p.base--p.test--loading-message.loading--message Watson is classifying the image to determine a match...
-    .error.test--error(style='display:none')
+    .error.test--error.display-none
       img.test--error-image.error--image(src='/images/icons/alert.svg')
       p.base--p.test--error-message.error--message Visual Recognition is not available right now...
-    .test--output.test--output-row(style='display:none')
+    .test--output.test--output-row.display-none
       .test--output-left
         .test--output-image-container
           img.test--output-image.landscape

--- a/views/includes/train.jade
+++ b/views/includes/train.jade
@@ -36,7 +36,7 @@
               .classifier(data-hasfile=0,data-idx=0)
                 .text
                   span.text-label
-                    a.base--a(href="javascript:void(0)") Select
+                    a.base--a(href="#") Select
                     |  or drag a zipped folder with at least 50 images
                   img.text-zip-image(src="images/VR zip icon.svg")
                 input(type="file",name="classupload",accept="application/zip")
@@ -45,7 +45,7 @@
               .classifier(data-hasfile=0,data-idx=1)
                 .text
                   span.text-label
-                    a.base--a(href="javascript:void(0)") Select
+                    a.base--a(href="#") Select
                     |  or drag a zipped folder with at least 50 images
                   img.text-zip-image(src="images/VR zip icon.svg")
                 input(type="file",name="classupload",accept="application/zip")
@@ -54,7 +54,7 @@
               .classifier(data-hasfile=0,data-idx=2)
                 .text
                   span.text-label
-                    a.base--a(href="javascript:void(0)") Select
+                    a.base--a(href="#") Select
                     |  or drag a zipped folder with at least 50 images
                   img.text-zip-image(src="images/VR zip icon.svg")
                 input(type="file",name="classupload",accept="application/zip")
@@ -67,7 +67,7 @@
               .classifier(data-hasfile=0,data-idx=3).negative
                 .text
                   span.text-label
-                    a.base--a(href="javascript:void(0)") Select
+                    a.base--a(href="#") Select
                     |  or drag a zipped folder with at least 50 images
                   img.text-zip-image(src="images/VR zip icon.svg")
                 input(type="hidden",name="classname",value="negative")

--- a/views/includes/use.jade
+++ b/views/includes/use.jade
@@ -5,15 +5,15 @@ div._demo--container
   div Choose a sample image or upload your own image (max 2mb) to try out Visual Recognition.
   +sampleInput('use')
 
-  .loading.use--loading(style='display:none')
+  .loading.use--loading.display-none
     .loader-container
       svg.loader(viewBox='25 25 50 50')
         circle.loader__path(cx='50', cy='50', r='20')
     p.base--p.use--loading-message.loading--message Watson is classifying the image to determine a match...
-  .error.use--error(style='display:none')
+  .error.use--error.display-none
     img.use--error-image.error--image(src='images/icons/alert.svg')
     p.base--p.use--error-message.error--message Visual Recognition is not available right now...
-  .use--output(style='display:none')
+  .use--output.display-none
     h2.base--h2.use--output-header Watson sees...
     .use--output-row
       .use--output-image-container

--- a/views/mixins/sampleInput.jade
+++ b/views/mixins/sampleInput.jade
@@ -25,8 +25,8 @@ mixin sampleInput(className, bundle, classifierId)
         +sampleImages(bundleImages, className, bundle)
 
     div(class='#{className}--url')
-      div(class='#{className}--invalid-url', style='display:none') Invalid URL
-      div(class='#{className}--invalid-image-url', style='display:none') The URL must end with .JPG, .GIF, or .PNG.
+      div(class='#{className}--invalid-url display-none') Invalid URL
+      div(class='#{className}--invalid-image-url display-none') The URL must end with .JPG, .GIF, or .PNG.
       input(class='#{className}--url-input base--input', type='text', placeholder='Or paste an image URL', name='url')
       input(class='#{className}--image-data-input base--input', type='hidden', name='image_data')
 


### PR DESCRIPTION
Required a few customizations and changes:
* fixed a bug where thermomitors were always being loaded from our bluemix instance
* swapped several style="display: none" attrs with a new .display-none class
* swapped several javascript:void(0) links with # and updated code to e.reventDefault()
* enabled iframing by watson-experience.mybluemix.net in csp
* set up endpoint to log violations
* whitelisted scripts from cdnjs, ajax to *.watsonplatform.net and teleaf
* enabled images from * and data: (apparently * doesn't include data: URIs)

run with VCAP_APPLICATION={} to test locally