### PR TITLE
Add the Visual Recognition Tool link to the demo page

### DIFF
--- a/views/includes/header.jade
+++ b/views/includes/header.jade
@@ -37,3 +37,5 @@
             a.base--a(href='https://github.com/watson-developer-cloud/visual-recognition-nodejs') Fork on Github
           li.base--li.banner--service-link-item
             a.base--a.base--start-free-in-bluemix(href='https://console.ng.bluemix.net/registration/?target=/catalog/services/visual-recognition/') Start free in Bluemix
+          li.base--li.banner--service-link-item
+            a.base--a(href='https://visual-recognition-tooling.mybluemix.net') Visual Recognition Tool


### PR DESCRIPTION
The Visual Recognition Tool has been deployed on Bluemix and we would like customers to be able to go directly to the tool directly from the demo